### PR TITLE
Adds TLS client and delivery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ build:
 		charm build -r --no-local-layers
 
 deploy: build
-	juju deploy ${JUJU_REPOSITORY}/builds/dex --to kubernetes-master/0
+	juju deploy ${JUJU_REPOSITORY}/builds/dex
 
 lint:
 	/usr/bin/python3 -m flake8 reactive lib
@@ -21,3 +21,10 @@ clean:
 
 clean-all:
 	rm -rf ${JUJU_REPOSITORY}/builds/dex
+
+# This is a best effort method to deploy the test formation. This presumes
+# unit 1 is always the kubernetes-master.
+test-formation: build
+	juju deploy kubernetes-core
+	juju deploy ${JUJU_REPOSITORY}/builds/dex --to 0
+	juju add-relation dex easyrsa

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 build:
-		charm build -r --no-local-layers
+		charm build -r
 
 deploy: build
 	juju deploy ${JUJU_REPOSITORY}/builds/dex

--- a/actions.yaml
+++ b/actions.yaml
@@ -1,0 +1,3 @@
+refresh:
+    description: |
+     Upgrade the dex snap from the configured channel.

--- a/actions/refresh
+++ b/actions/refresh
@@ -1,0 +1,14 @@
+#!/usr/bin/python3
+import sys
+import os
+sys.path.append(os.path.join(os.getenv('CHARM_DIR'), 'lib'))
+print(sys.path)
+from charms import layer
+from charms.layer import snap
+from charmhelpers.core.hookenv import config
+
+SNAP_CHANNEL = config('channel')
+opts = layer.options('dex')
+SNAP_PACKAGE = opts['dex_snap']
+
+snap.install(SNAP_PACKAGE, channel=SNAP_CHANNEL)

--- a/config.yaml
+++ b/config.yaml
@@ -27,6 +27,10 @@ options:
     type: int
     default: 5556
     description: Port to bind the authorization daemon.
+  portal-port:
+    type: int
+    default: 5555
+    description: Port to run the auth-portal ui.
   expire-signing-keys:
     type: int
     default: 6

--- a/layer.yaml
+++ b/layer.yaml
@@ -2,6 +2,7 @@ repo: https://github.com/juju-solutions/layer-dex
 includes:
  - 'layer:basic'
  - 'layer:snap'
+ - 'layer:tls-client'
 defines:
     dex_snap:
       type: string
@@ -9,3 +10,8 @@ defines:
       description: |
         "Snap package to install from snapcraft.io by default when no snap
         resource has been provided."
+options:
+  tls-client:
+    ca_certificate_path: /var/snap/lazy-dex/common/ca.crt
+    server_certificate_path: /var/snap/lazy-dex/common/server.crt
+    server_key_path: /var/snap/lazy-dex/common/server.key

--- a/layer.yaml
+++ b/layer.yaml
@@ -3,6 +3,7 @@ includes:
  - 'layer:basic'
  - 'layer:snap'
  - 'layer:tls-client'
+ - 'interface:kube-oidc'
 defines:
     dex_snap:
       type: string

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -19,7 +19,7 @@ provides:
 #   kube-control:
 #     interface: kube-control
 resources:
-  dex:
+  lazy-dex:
     type: file
     filename: dex.snap
     description: The dex snap package

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,11 +13,8 @@ series:
     - xenial
 subordinate: false
 provides:
-  authentication:
-    interface: dex
-# requires:
-#   kube-control:
-#     interface: kube-control
+  authorization:
+    interface: kube-oidc
 resources:
   lazy-dex:
     type: file

--- a/reactive/dex.py
+++ b/reactive/dex.py
@@ -4,39 +4,65 @@ from charms.reactive import hook
 from charms.reactive import when
 from charms.reactive import when_any
 from charms.reactive import when_not
-# from charms.reactive import set_state
+from charms.reactive import remove_state
+from charms.reactive import set_state
 from charms.templating.jinja2 import render
 
+from charmhelpers.core import unitdata
+from charmhelpers.core.hookenv import application_version_set
 from charmhelpers.core.hookenv import config
 from charmhelpers.core.hookenv import close_port
+from charmhelpers.core.hookenv import local_unit
+from charmhelpers.core.hookenv import log
 from charmhelpers.core.hookenv import open_port
 from charmhelpers.core.hookenv import status_set
 from charmhelpers.core.hookenv import unit_get
+from charmhelpers.core.hookenv import unit_public_ip
+from charmhelpers.core.hookenv import unit_private_ip
+
 from charmhelpers.core.host import service_restart
 
 from lib.utilities import convert_dict_keys
 
+from shlex import split
 from subprocess import check_call
+from subprocess import check_output
 from subprocess import CalledProcessError
 
 import os
+import random
+import socket
+import string
 
 
 @hook('stop')
 def remove_dex():
-    ''' Remove the snap and purge configuration files on the way out '''
+    ''' Remove the snap and purge configuration files on the way out. '''
     opts = layer.options('dex')
     # This is ugly, but snap.remove resets the state. This will ensure we
     # clean up after ourseles on the way out.
     check_call(['snap', 'remove', opts['dex_snap']])
 
 
+@when('certificates.server.cert.available')
+def stop_object_proliferation(certs):
+    set_state('dex.ssl.ready')
+
+
+@hook('upgrade-charm')
+def upgrade_charm():
+    ''' Remove the snap installation state to trigger a refresh '''
+    remove_state('snap.installed.lazy-dex')
+
+
 @hook('update-status')
 def update_status():
-    ''' Invoke the health checks and do any additional status messaging '''
+    ''' Invoke the health checks and do any additional status messaging. '''
     invoke_health_message()
+    report_dex_version()
 
 
+@when('dex.ssl.ready')
 @when_not('snap.installed.lazy-dex')
 def install_dex():
     ''' Install dex on first run '''
@@ -46,6 +72,7 @@ def install_dex():
     invoke_health_message()
 
 
+@when('dex.ssl.ready')
 @when('config.changed.channel')
 def update_dex_channel():
     ''' React to channel changes and refresh the dex snap '''
@@ -54,21 +81,31 @@ def update_dex_channel():
     invoke_health_message()
 
 
-# TODO: Make this actually reconfigure dex
 @when('config.changed.auth-port')
 def cycle_ports():
-    ''' Close the previous port and open the currently configured port '''
+    ''' Close the previous port and open the currently configured port. '''
     cfg = config()
     if cfg.previous('auth-port'):
         close_port(cfg.previous('auth-port'))
         open_port(config('auth-port'))
 
 
+@when('dex.ssl.ready')
+@when('config.changed.portal-port')
+def cycle_portal():
+    cfg = config()
+    if cfg.previous('portal-port'):
+        close_port(cfg.previous('portal-port'))
+        open_port(config('portal-port'))
+    # TODO: service_restart('dex-auth-portal')
+
+
+@when('dex.ssl.ready')
 @when_any('config.changed.auth-port', 'config.changed.github-client',
           'config.changed.github-secret', 'config.changed.google-client',
           'config.changed.google-secret', 'config.changed.expire-signing-keys',
           'config.changed.expire-id-tokens', 'config.changed.demo-mode',
-          'config.changed.github-org')
+          'config.changed.github-org', 'config.changed.portal-port')
 def render_dex_template():
     ''' Re-render the dex service template and recycle the daemon to ingest the
     new config.'''
@@ -79,14 +116,59 @@ def render_dex_template():
     # clone the config  and layer options dict and prep the keys
     # for jinja templating
     context = convert_dict_keys(config())
-    opts = convert_dict_keys(layer.options('dex'))
-
-    context.update({'issuer': unit_get('public-address')})
-    context.update(opts)
+    dex_opts = convert_dict_keys(layer.options('dex'))
+    tls_opts = convert_dict_keys(layer.options('tls-client'))
+    context.update({'issuer': unit_get('public-address'),
+                    'portal_token': portal_token()})
+    context.update(dex_opts)
+    context.update(tls_opts)
 
     # instantiate a config object and pass it in as context
     render('config.yaml.jinja2', config_path, context)
     service_restart('snap.lazy-dex.daemon')
+    remove_state('auth-portal.available')
+
+
+@when_not('certificates.available')
+def missing_relation_notice():
+    status_set('blocked', 'Missing relation to certificate authority.')
+
+
+@when('certificates.available')
+@when_not('dex.ssl.requested')
+def prepare_tls_certificates(tls):
+    status_set('maintenance', 'Requesting tls certificates.')
+    common_name = unit_public_ip()
+    sans = []
+    sans.append(unit_public_ip())
+    sans.append(unit_private_ip())
+    sans.append(socket.gethostname())
+    certificate_name = local_unit().replace('/', '_')
+    tls.request_server_cert(common_name, sans, certificate_name)
+    set_state('dex.ssl.requested')
+
+
+@when('snap.installed.lazy-dex')
+@when_not('auth-portal.available')
+def start_auth_portal():
+    ''' Activate the authorization portal which enables the oauth workflow '''
+    opts = layer.options('dex')
+    arg_path = os.path.join(os.path.sep, 'var', 'snap', opts['dex_snap'],
+                            'common', 'portal-args')
+
+    issuer_uri = "https://{0}:{1}/dex".format(unit_get('public-address'),
+                                              config('auth-port'))
+    redirect_uri = "http://{0}:{1}/callback".format(unit_get('public-address'),
+                                                    config('portal-port'))
+    portal_args = {'issuer': issuer_uri,
+                   'redirect-uri': redirect_uri,
+                   'client-id': 'auth-portal',
+                   'client-secret': portal_token(),
+                   'listen': 'http://0.0.0.0:{}'.format(config('portal-port'))}
+    log('Configuring auth portal args as {}'.format(arg_path), 'INFO')
+    with open(arg_path, 'w+') as fp:
+        for k in portal_args.keys():
+            fp.write('--{0}={1} '.format(k, portal_args[k]))
 
 
 def invoke_health_message():
@@ -100,4 +182,33 @@ def invoke_health_message():
     if return_code < 1:
         status_set('active', 'Dex is active.')
     else:
-        status_set('error', 'Error checking dex.')
+        status_set('waiting', 'Error checking dex.')
+
+
+def portal_token(size=32):
+    ''' Generate a client token for client/server communication between dex
+    and the authentication portal.
+
+    param size - the length of the ascii token.'''
+    db = unitdata.kv()
+    if not db.get('portal-token'):
+        chars = string.ascii_uppercase + string.ascii_lowercase + string.digits
+        token = ''.join(random.choice(chars) for _ in range(size))
+        db.set('portal-token', token)
+    return db.get('portal-token')
+
+
+def report_dex_version():
+    ''' Declare the version of dex installed via juju status '''
+    # set the application version while we're here
+    cmd = "/snap/bin/lazy-dex.dex version"
+    try:
+        raw_out = check_output(split(cmd))
+    except FileNotFoundError:  # noqa
+        # We haven't installed dex yet, dont break progression.
+        return
+    version = ''
+    for line in raw_out.split(b'\n'):
+        if b'dex' in line:
+            version = line.split(b' ')[-1].replace(b'v', b'')
+    application_version_set(version)

--- a/templates/config.yaml.jinja2
+++ b/templates/config.yaml.jinja2
@@ -6,7 +6,6 @@
 # This is the canonical URL that all clients MUST use to refer to dex. If a
 # path is provided, dex's HTTP service will listen at a non-root URL.
 issuer: http://{{ issuer }}:{{ auth_port }}/dex
-
 # The storage configuration determines where dex stores its state. Supported
 # options include SQL flavors and Kubernetes third party resources.
 #
@@ -14,20 +13,16 @@ issuer: http://{{ issuer }}:{{ auth_port }}/dex
 storage:
   type: sqlite3
   config:
-    file: /var/snap/lazy-dex/common/dex.db
-
+    file: /var/snap/{{ dex_snap }}/common/dex.db
 # Configuration for the HTTP endpoints.
 web:
-  http: 0.0.0.0:{{ auth_port }}
+  https: 0.0.0.0:{{ auth_port }}
   # Uncomment for HTTPS options.
-  # https: 127.0.0.1:5554
-  # tlsCert: /etc/dex/tls.crt
-  # tlsKey: /etc/dex/tls.key
-
-
+  # http: 127.0.0.1:5554
+  tlsCert: {{ server_certificate_path }}
+  tlsKey: {{ server_key_path }}
 frontend:
-  dir: /var/snap/lazy-dex/current/web
-
+  dir: /var/snap/{{ dex_snap }}/current/web
 
 {% if exire_signing_keys and expire_id_tokens %}
 # Uncomment this block to enable configuration for the expiration time durations.
@@ -35,36 +30,28 @@ expiry:
    signingKeys: "{{ expire_signing_keys }}h"
    idTokens: "{{ expire_id_tokens }}h"
 {% endif %}
-
 {% if debug %}
 # Options for controlling the logger.
 logger:
    level: "debug"
    format: "text" # can also be "json"
 {% endif %}
-
-
-# TODO: Remove this or configure it appropriately for the context of k8s
-{% if demo_mode %}
 # Instead of reading from an external storage, use this list of clients.
 # If this option isn't chosen clients may be added through the gRPC API.
 staticClients:
-- id: example-app
+- id: auth-portal
   redirectURIs:
-  - 'http://{{ issuer }}:{{ auth_port }}/callback'
-  name: 'Example App'
-  secret: ZXhhbXBsZS1hcHAtc2VjcmV0
-{% endif %}
+  - 'http://{{ issuer }}:{{ portal_port }}/callback'
+  name: 'Auth Portal'
+  secret: {{ portal_token }}
 
 connectors:
-{% if demo_mode %}
+{% if demo_mode -%}
 - type: mockCallback
   id: mock
   name: Example
 {% endif %}
-
-
-{% if github_client and github_secret %}
+{% if github_client and github_secret -%}
 - type: github
   id: github
   name: GitHub
@@ -72,14 +59,13 @@ connectors:
     # Credentials can be string literals or pulled from the environment.
     clientID: {{ github_client }}
     clientSecret: {{ github_secret }}
-    redirectURI: http://{{ issuer }}:{{ auth_port }}/dex/callback
+    redirectURI: https://{{ issuer }}:{{ auth_port }}/dex/callback
     {% if github_org %}
     # NOTE: This is an EXPERIMENTAL config option and will likely change.
     org: {{ github_org }}
     {% endif %}
 {% endif %}
-
-{% if google_client and google_secret %}
+{% if google_client and google_secret -%}
  - type: oidc
    id: google
    name: Google
@@ -88,13 +74,11 @@ connectors:
 #     # Connector config values starting with a "$" will read from the environment.
      clientID: {{ google_client }}
      clientSecret: {{ google_secret }}
-     redirectURI: http://{{ issuer }}:{{ auth_port }}/dex/callback
+     redirectURI: https://{{ issuer }}:{{ auth_port }}/dex/callback
 {% endif %}
-
-{% if demo_mode %}
+{% if demo_mode -%}
 # Let dex keep a list of passwords which can be used to login to dex.
 enablePasswordDB: true
-
 # A static list of passwords to login the end user. By identifying here, dex
 # won't look in its underlying storage for passwords.
 #

--- a/templates/config.yaml.jinja2
+++ b/templates/config.yaml.jinja2
@@ -5,7 +5,7 @@
 # The base path of dex and the external name of the OpenID Connect service.
 # This is the canonical URL that all clients MUST use to refer to dex. If a
 # path is provided, dex's HTTP service will listen at a non-root URL.
-issuer: http://{{ issuer }}:{{ auth_port }}/dex
+issuer: https://{{ issuer }}:{{ auth_port }}/dex
 # The storage configuration determines where dex stores its state. Supported
 # options include SQL flavors and Kubernetes third party resources.
 #


### PR DESCRIPTION
- New action to refresh the snap
    - Moves the snap declaration into layer.yaml for easy switch-out later
    - Updates the config.yaml template to work with configuration segments
    - Adds initial crumbs of kube-identity relationship
    - Convert config keys to jinja2 friendly _'s
    - cleanup logic during stop hook, health checks, and reactions to config-changed events